### PR TITLE
fix: use fileURLToPath for proper URL resolving in Windows

### DIFF
--- a/.changeset/twelve-cities-look.md
+++ b/.changeset/twelve-cities-look.md
@@ -1,0 +1,5 @@
+---
+"@workleap/migrations": patch
+---
+
+Fix CLI's url resolving method in Windows

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { join, resolve } from "path";
 import { cwd } from "process";
 import { simpleGit } from "simple-git";
 import tempDir from "temp-dir";
+import { fileURLToPath } from "url";
 import packageJson from "../package.json" with { type: "json" };
 
 
@@ -53,7 +54,7 @@ function runCommand(mode: "migrate" | "analyze", repoPath: string, targetPath: s
   const spinner = ora("Running command...").start();
 
   //get the folder of path to the running cli script
-  const cliPath = resolve(import.meta.url.replace("file:", ""), "..");
+  const cliPath = resolve(fileURLToPath(import.meta.url), "..");
 
   try {
     const args: string[] = [


### PR DESCRIPTION
## Summary

Fixes CLI's URL resolving method in Windows by replacing manual URL string manipulation with the proper `fileURLToPath` utility function.

## Changes

- Replace `import.meta.url.replace('file:', '')` with `fileURLToPath(import.meta.url)`
- Add missing import for `fileURLToPath` from 'url' module
- Ensures cross-platform compatibility for file path resolution

## Why

The previous implementation using string replacement (`import.meta.url.replace('file:', '')`) doesn't work correctly on Windows systems where file URLs have different formatting. The `fileURLToPath` utility handles cross-platform URL-to-path conversion properly.

## Testing

- ✅ ESLint checks pass
- ✅ TypeScript compilation passes
- Fixes CLI execution issues on Windows systems

## Related

- Addresses Windows compatibility issues in the CLI tool
- Maintains existing functionality on Unix-based systems